### PR TITLE
Fix for issue #15

### DIFF
--- a/elFinder.NetCore.Web/Controllers/AzureStorageController.cs
+++ b/elFinder.NetCore.Web/Controllers/AzureStorageController.cs
@@ -49,7 +49,8 @@ namespace elFinder.NetCore.Web.Controllers
             {
                 //IsReadOnly = !User.IsInRole("Administrators")
                 IsReadOnly = false, // Can be readonly according to user's membership permission
-                Alias = "Files", // Beautiful name given to the root/home folder
+				IsLocked = false, // If locked, files and directories cannot be deleted, renamed or moved
+				Alias = "Files", // Beautiful name given to the root/home folder
                 MaxUploadSizeInKb = 2048, // Limit imposed to user uploaded file <= 2048 KB
                 //LockedFolders = new List<string>(new string[] { "Folder1" })
             };

--- a/elFinder.NetCore.Web/Controllers/FileSystemController.cs
+++ b/elFinder.NetCore.Web/Controllers/FileSystemController.cs
@@ -37,7 +37,8 @@ namespace elFinder.NetCore.Web.Controllers
             {
                 //IsReadOnly = !User.IsInRole("Administrators")
                 IsReadOnly = false, // Can be readonly according to user's membership permission
-                Alias = "Files", // Beautiful name given to the root/home folder
+				IsLocked = false, // If locked, files and directories cannot be deleted, renamed or moved
+				Alias = "Files", // Beautiful name given to the root/home folder
                 //MaxUploadSizeInKb = 2048, // Limit imposed to user uploaded file <= 2048 KB
                 //LockedFolders = new List<string>(new string[] { "Folder1" })
             };

--- a/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
+++ b/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
@@ -461,11 +461,6 @@ namespace elFinder.NetCore.Drivers.FileSystem
             var response = new RemoveResponseModel();
             foreach (var path in paths)
             {
-                if (path.RootVolume.IsReadOnly)
-                {
-                    continue;
-                }
-
                 await RemoveThumbsAsync(path);
                 if (path.IsDirectory)
                 {

--- a/elFinder.NetCore/RootVolume.cs
+++ b/elFinder.NetCore/RootVolume.cs
@@ -61,7 +61,7 @@ namespace elFinder.NetCore
         /// <summary>
         /// Get or sets if root is locked (user can't remove, rename or delete files or subdirectories)
         /// </summary>
-        public bool IsLocked { get; }
+        public bool IsLocked { get; set; }
 
         /// <summary>
         /// Get or sets if root for read only (users can't change file)


### PR DESCRIPTION
This should be the correct fix for issue #15.
According to the [API](https://github.com/Studio-42/elFinder/wiki/Client-Server-API-2.1), the correct way to configure a file, folder or the whole volume so that they can't be deleted, renamed or moved is to set the IsLocked flag to true. elFinder takes care of the rest for us.
I made that flag "setable" at the volume level so it takes care of the problem for both FileSystem and Azure Storage....
