### PR TITLE
Added compatibility with ASP.NET Core 3.0

### DIFF
--- a/elFinder.NetCore.AzureStorage/elFinder.NetCore.AzureStorage.csproj
+++ b/elFinder.NetCore.AzureStorage/elFinder.NetCore.AzureStorage.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <Authors>Yevhen Noskov, Leniel Macaferi, Matt Gordon, Flavio Smirne</Authors>
     <Company>N/A</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -8,11 +8,16 @@
     <Description>Microsoft Azure Storage driver for elFinder.NetCore</Description>
     <PackageLicenseUrl></PackageLicenseUrl>
     <Version>1.2.1</Version>
+    <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.2.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.2'">
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/elFinder.NetCore.Web/Startup.cs
+++ b/elFinder.NetCore.Web/Startup.cs
@@ -1,10 +1,10 @@
-﻿using System.IO;
-using elFinder.NetCore.Drivers.AzureStorage;
+﻿using elFinder.NetCore.Drivers.AzureStorage;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.IO;
 
 namespace elFinder.NetCore.Web
 {
@@ -33,12 +33,12 @@ namespace elFinder.NetCore.Web
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddControllersWithViews()
+                .AddNewtonsoftJson();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -56,12 +56,11 @@ namespace elFinder.NetCore.Web
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+            app.UseRouting();
 
-            app.UseMvc(routes =>
+            app.UseEndpoints(endpoints =>
             {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
             });
 
             WebRootPath = env.WebRootPath;

--- a/elFinder.NetCore.Web/elFinder.NetCore.Web.csproj
+++ b/elFinder.NetCore.Web/elFinder.NetCore.Web.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <UserSecretsId>a13535c9-0a1e-4ed1-8437-bafcc87a57a9</UserSecretsId>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Authors>Yevhen Noskov, Leniel Macaferi, Matt Gordon, Flavio Smirne</Authors>
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/elFinder.NetCore/elFinder.NetCore.csproj
+++ b/elFinder.NetCore/elFinder.NetCore.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
     <Authors>Yevhen Noskov, Leniel Macaferi, Matt Gordon, Flavio Smirne</Authors>
     <Company>N/A</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -8,6 +8,8 @@
     <PackageProjectUrl>https://github.com/gordon-matt/elFinder.NetCore</PackageProjectUrl>
     <Version>1.2.1</Version>
     <PackageLicenseUrl></PackageLicenseUrl>
+    <OutputType>Library</OutputType>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,9 +19,14 @@
   <ItemGroup>
     <EmbeddedResource Include="MimeTypes.txt" />
   </ItemGroup>
-
-  <ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.2'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.0'">
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently elFinder.NetCore is only compatible with ASP.NET Core 2.2.
If you add these packages to a ASP.NET Core 3.0 project you will get some build warnings.

I've updated both nuget packages to target both ASP.NET Core 2.2 and ASP.NET Core 3.0
I've also migrated the elFinder.NetCore.Web demo project to ASP.NET Core 3.0.