### PR TITLE
Support onlyMimes features, add MimeDetect option of Connector

### DIFF
--- a/elFinder.NetCore.AzureStorage/Drivers/AzureStorage/AzureStorageDirectory.cs
+++ b/elFinder.NetCore.AzureStorage/Drivers/AzureStorage/AzureStorageDirectory.cs
@@ -85,7 +85,7 @@ namespace elFinder.NetCore.Drivers.AzureStorage
             return result;
         }
 
-        public async Task<IEnumerable<IFile>> GetFilesAsync()
+        public async Task<IEnumerable<IFile>> GetFilesAsync(IEnumerable<string> mimes)
         {
             var result = new List<IFile>();
 

--- a/elFinder.NetCore.AzureStorage/Drivers/AzureStorage/AzureStorageDriver.cs
+++ b/elFinder.NetCore.AzureStorage/Drivers/AzureStorage/AzureStorageDriver.cs
@@ -10,6 +10,7 @@ using elFinder.NetCore.Models;
 using elFinder.NetCore.Models.Commands;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 using Microsoft.WindowsAzure.Storage.File;
 
 namespace elFinder.NetCore.Drivers.AzureStorage
@@ -340,7 +341,7 @@ namespace elFinder.NetCore.Drivers.AzureStorage
             return await Json(response);
         }
 
-        public async Task<JsonResult> InitAsync(FullPath path)
+        public async Task<JsonResult> InitAsync(FullPath path, IEnumerable<string> mimes = null)
         {
             if (path == null)
             {
@@ -408,7 +409,7 @@ namespace elFinder.NetCore.Drivers.AzureStorage
             return await Json(response);
         }
 
-        public async Task<JsonResult> ListAsync(FullPath path, IEnumerable<string> intersect)
+        public async Task<JsonResult> ListAsync(FullPath path, IEnumerable<string> intersect, IEnumerable<string> mimes = null)
         {
             var response = new ListResponseModel();
 
@@ -483,7 +484,7 @@ namespace elFinder.NetCore.Drivers.AzureStorage
             return await Json(response);
         }
 
-        public async Task<JsonResult> OpenAsync(FullPath path, bool tree)
+        public async Task<JsonResult> OpenAsync(FullPath path, bool tree, IEnumerable<string> mimes = null)
         {
             var response = new OpenResponse(await BaseModel.CreateAsync(path.Directory, path.RootVolume), path);
 
@@ -900,7 +901,7 @@ namespace elFinder.NetCore.Drivers.AzureStorage
             var response = new SizeResponseModel();
 
             // Add file sizes.
-            foreach (var file in await d.GetFilesAsync())
+            foreach (var file in await d.GetFilesAsync(default(StringValues)))
             {
                 response.FileCount++;
                 response.Size += await file.LengthAsync;

--- a/elFinder.NetCore.Web/Controllers/FileSystemController.cs
+++ b/elFinder.NetCore.Web/Controllers/FileSystemController.cs
@@ -41,11 +41,15 @@ namespace elFinder.NetCore.Web.Controllers
                 Alias = "Files", // Beautiful name given to the root/home folder
                 //MaxUploadSizeInKb = 2048, // Limit imposed to user uploaded file <= 2048 KB
                 //LockedFolders = new List<string>(new string[] { "Folder1" })
+                //ThumbnailSize = 256 //Change default thumbnail size
             };
 
             driver.AddRoot(root);
 
-            return new Connector(driver);
+            return new Connector(driver)
+            {
+                //MimeDetect = MimeDetect.INTERNAL //change MimeDetect option for support onlyMimes in client
+            };
         }
     }
 }

--- a/elFinder.NetCore.Web/Views/FileManager/Index.cshtml
+++ b/elFinder.NetCore.Web/Views/FileManager/Index.cshtml
@@ -40,8 +40,8 @@
                         ['selectall', 'selectnone', 'selectinvert'],
                         ['view', 'sort']
                     ]
-                }
-
+                },
+                //onlyMimes: ["text/plain"] // Get only files of requested mime types
                 //lang: 'vi', // Change language
             };
             $('#elfinder').elfinder(options).elfinder('instance');

--- a/elFinder.NetCore/Connector.cs
+++ b/elFinder.NetCore/Connector.cs
@@ -19,6 +19,8 @@ namespace elFinder.NetCore
     {
         private readonly IDriver driver;
 
+        //auto, internal, finfo, mime_content_type
+        public string MimeDetect { get; set; } = "auto";
         public Connector(IDriver driver)
         {
             this.driver = driver;
@@ -75,7 +77,10 @@ namespace elFinder.NetCore
                 case "ls":
                     {
                         var path = await driver.ParsePathAsync(parameters.GetValueOrDefault("target"));
-                        return await driver.ListAsync(path, parameters.GetValueOrDefault("intersect[]"));
+                        var intersects = parameters.GetValueOrDefault("intersect[]");
+                        var mimes = MimeDetect == "internal" ?
+                            parameters.GetValueOrDefault("mimes[]") : default;
+                        return await driver.ListAsync(path, intersects, mimes);
                     }
                 case "mkdir":
                     {
@@ -93,15 +98,14 @@ namespace elFinder.NetCore
                 case "open":
                     {
                         var path = await driver.ParsePathAsync(parameters.GetValueOrDefault("target"));
-
-                        if (parameters.GetValueOrDefault("init") == "1")
-                        {
-                            return await driver.InitAsync(path);
-                        }
+                        var mimes = MimeDetect == "internal" ?
+                            parameters.GetValueOrDefault("mimes[]") : default;
+                        var init = parameters.GetValueOrDefault("init") == "1";
+                        var tree = parameters.GetValueOrDefault("tree") == "1";
+                        if (init)
+                            return await driver.InitAsync(path, mimes);
                         else
-                        {
-                            return await driver.OpenAsync(path, parameters.GetValueOrDefault("tree") == "1");
-                        }
+                            return await driver.OpenAsync(path, tree, mimes);
                     }
                 case "parents":
                     {

--- a/elFinder.NetCore/Constants.cs
+++ b/elFinder.NetCore/Constants.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace elFinder.NetCore
+{
+    public static class MimeDetect
+    {
+        public const string INTERNAL = "internal";
+    }
+}

--- a/elFinder.NetCore/Drivers/BaseDriver.cs
+++ b/elFinder.NetCore/Drivers/BaseDriver.cs
@@ -2,6 +2,7 @@
 using System.IO.Compression;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 
 namespace elFinder.NetCore.Drivers
 {
@@ -36,7 +37,7 @@ namespace elFinder.NetCore.Drivers
                 await AddDirectoryToArchiveAsync(zipFile, dir, entryName);
             }
 
-            var files = await directoryInfo.GetFilesAsync();
+            var files = await directoryInfo.GetFilesAsync(default(StringValues));
             foreach (var file in files)
             {
                 zipFile.CreateEntryFromFile(file.FullName, entryName + file.Name);

--- a/elFinder.NetCore/Drivers/FileSystem/FileSystemDirectory.cs
+++ b/elFinder.NetCore/Drivers/FileSystem/FileSystemDirectory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using elFinder.NetCore.Helpers;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -61,9 +62,13 @@ namespace elFinder.NetCore.Drivers.FileSystem
             return Task.FromResult(dirs);
         }
 
-        public Task<IEnumerable<IFile>> GetFilesAsync()
+        public Task<IEnumerable<IFile>> GetFilesAsync(IEnumerable<string> mimes)
         {
-            var files = directoryInfo.GetFiles().Select(f => new FileSystemFile(f) as IFile);
+            var files = directoryInfo.GetFiles().Select(f => new FileSystemFile(f) as IFile)
+                 .Where(f => !mimes.Any() || mimes.Any(m =>
+                     m.Contains("/") ?
+                     MimeHelper.GetMimeType(f.Extension) == m :
+                     MimeHelper.GetMimeType(f.Extension).StartsWith(m + "/")));
             return Task.FromResult(files);
         }
 

--- a/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
+++ b/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
@@ -294,7 +294,7 @@ namespace elFinder.NetCore.Drivers.FileSystem
             return await Json(response);
         }
 
-        public async Task<JsonResult> InitAsync(FullPath path)
+        public async Task<JsonResult> InitAsync(FullPath path, IEnumerable<string> mimes)
         {
             if (path == null)
             {
@@ -309,7 +309,7 @@ namespace elFinder.NetCore.Drivers.FileSystem
 
             var response = new InitResponseModel(await BaseModel.CreateAsync(path.Directory, path.RootVolume), new Options(path));
 
-            foreach (var item in await path.Directory.GetFilesAsync())
+            foreach (var item in await path.Directory.GetFilesAsync(mimes))
             {
                 if (!item.Attributes.HasFlag(FileAttributes.Hidden))
                 {
@@ -349,11 +349,12 @@ namespace elFinder.NetCore.Drivers.FileSystem
             return await Json(response);
         }
 
-        public async Task<JsonResult> ListAsync(FullPath path, IEnumerable<string> intersect)
+        public async Task<JsonResult> ListAsync(FullPath path, IEnumerable<string> intersect,
+            IEnumerable<string> mimes)
         {
             var response = new ListResponseModel();
 
-            foreach (var item in await path.Directory.GetFilesAsync())
+            foreach (var item in await path.Directory.GetFilesAsync(mimes))
             {
                 if (!item.Attributes.HasFlag(FileAttributes.Hidden))
                 {
@@ -413,10 +414,10 @@ namespace elFinder.NetCore.Drivers.FileSystem
             return await Json(response);
         }
 
-        public async Task<JsonResult> OpenAsync(FullPath path, bool tree)
+        public async Task<JsonResult> OpenAsync(FullPath path, bool tree, IEnumerable<string> mimes)
         {
             var response = new OpenResponse(await BaseModel.CreateAsync(path.Directory, path.RootVolume), path);
-            foreach (var item in await path.Directory.GetFilesAsync())
+            foreach (var item in await path.Directory.GetFilesAsync(mimes))
             {
                 if (!item.Attributes.HasFlag(FileAttributes.Hidden))
                 {

--- a/elFinder.NetCore/Drivers/IDirectory.cs
+++ b/elFinder.NetCore/Drivers/IDirectory.cs
@@ -27,6 +27,6 @@ namespace elFinder.NetCore.Drivers
 
         Task<IEnumerable<IDirectory>> GetDirectoriesAsync();
 
-        Task<IEnumerable<IFile>> GetFilesAsync();
+        Task<IEnumerable<IFile>> GetFilesAsync(IEnumerable<string> mimes);
     }
 }

--- a/elFinder.NetCore/Drivers/IDriver.cs
+++ b/elFinder.NetCore/Drivers/IDriver.cs
@@ -21,15 +21,15 @@ namespace elFinder.NetCore
 
         Task<JsonResult> GetAsync(FullPath path);
 
-        Task<JsonResult> InitAsync(FullPath path);
+        Task<JsonResult> InitAsync(FullPath path, IEnumerable<string> mimes);
 
-        Task<JsonResult> ListAsync(FullPath path, IEnumerable<string> intersect);
+        Task<JsonResult> ListAsync(FullPath path, IEnumerable<string> intersect, IEnumerable<string> mimes);
 
         Task<JsonResult> MakeDirAsync(FullPath path, string name, IEnumerable<string> dirs);
 
         Task<JsonResult> MakeFileAsync(FullPath path, string name);
 
-        Task<JsonResult> OpenAsync(FullPath path, bool tree);
+        Task<JsonResult> OpenAsync(FullPath path, bool tree, IEnumerable<string> mimes);
 
         Task<JsonResult> ParentsAsync(FullPath path);
 

--- a/elFinder.NetCore/Models/BaseModel.cs
+++ b/elFinder.NetCore/Models/BaseModel.cs
@@ -61,7 +61,7 @@ namespace elFinder.NetCore.Models
         public byte Locked { get; protected set; }
 
         public static async Task<FileModel> CreateAsync(IFile file, RootVolume volume)
-		{
+        {
             if (file == null) throw new ArgumentNullException("file");
             if (volume == null) throw new ArgumentNullException("volume");
 
@@ -75,12 +75,20 @@ namespace elFinder.NetCore.Models
             {
                 using (var stream = await file.OpenReadAsync())
                 {
-                    var dim = volume.PictureEditor.ImageSize(stream);
-                    response = new ImageModel
+                    try
                     {
-                        Thumbnail = await volume.GenerateThumbHashAsync(file),
-                        Dimension = $"{dim.Width}x{dim.Height}"
-                    };
+                        var dim = volume.PictureEditor.ImageSize(stream);
+                        response = new ImageModel
+                        {
+                            Thumbnail = await volume.GenerateThumbHashAsync(file),
+                            Dimension = $"{dim.Width}x{dim.Height}"
+                        };
+                    }
+                    //catch for non standard images
+                    catch (Exception)
+                    {
+                        response = new FileModel();
+                    }
                 }
             }
             else

--- a/elFinder.NetCore/RootVolume.cs
+++ b/elFinder.NetCore/RootVolume.cs
@@ -35,7 +35,6 @@ namespace elFinder.NetCore
             RootDirectory = rootDirectory;
             Url = url;
             UploadOverwrite = true;
-            ThumbnailSize = 48;
             PictureEditor = new DefaultPictureEditor();
 
             // https://github.com/EvgenNoskov/Elfinder.NET/blob/fb19f17a3682ed81cadcfea978dcce575806eebd/docs/Documentation.md
@@ -128,7 +127,7 @@ namespace elFinder.NetCore
         /// <summary>
         /// Get or sets thumbnails size
         /// </summary>
-        public int ThumbnailSize { get; }
+        public int ThumbnailSize { get; set; } = 48;
 
         /// <summary>
         /// Get ot sets thumbnails url


### PR DESCRIPTION
+ Connector.cs: add Connector's MimeDetect option, parameters extraction and process request with mimes option

+ IDirectory.cs: change method signature, add list mimes paraemter
+ BaseDriver.cs, IDriver.cs, FileSystemDriver.cs: affected files
+ FileSystemDirectory.cs: implement function: list only files of mimes type if requested.
+ Constants.cs: temp constant values for MimeDectect option
---------------------
+ BaseModel.cs: fix for failure when uploading non-standard image. issue ref: https://github.com/gordon-matt/elFinder.NetCore/issues/36