### PR TITLE
"onlyMimes" option should be able to display all files belong to a type

### DIFF
--- a/elFinder.NetCore/Drivers/FileSystem/FileSystemDirectory.cs
+++ b/elFinder.NetCore/Drivers/FileSystem/FileSystemDirectory.cs
@@ -66,7 +66,10 @@ namespace elFinder.NetCore.Drivers.FileSystem
             var files = directoryInfo.GetFiles().Select(f => new FileSystemFile(f) as IFile);
 
             if (mimeTypes != null && mimeTypes.Count() > 0)
-                files = files.Where(f => mimeTypes.Contains(f.MimeType));
+                files = files.Where(f => mimeTypes.Any(m =>
+                    m.Contains("/") ?
+                    f.MimeType == m :
+                    f.MimeType.StartsWith(m + "/")));
 
             return Task.FromResult(files);
         }


### PR DESCRIPTION
"onlyMimes" option should be able to display all files belong to a type. e.g: onlyMimes: ["image"] should display all image files
Reference: https://github.com/Studio-42/elFinder/wiki/Client-configuration-options-2.1#onlyMimes