### PR TITLE
Add handle for File/FolderNotFound exception, add i18n support for some custom messages

### DIFF
--- a/elFinder.NetCore.Web/Views/FileManager/Index.cshtml
+++ b/elFinder.NetCore.Web/Views/FileManager/Index.cshtml
@@ -12,6 +12,7 @@
             var myCommands = elFinder.prototype._options.commands;
             var disabled = ['callback', 'chmod', 'editor', 'netmount', 'ping', 'zipdl', 'help']; // Not yet implemented commands in elFinder.NetCore
             elFinder.prototype.i18.en.messages.TextArea = "Edit";
+            elFinder.prototype.i18.en.messages.errNewNameSelection = 'Unable to create new file with name "$1"';
 
             $.each(disabled, function (i, cmd) {
                 (idx = $.inArray(cmd, myCommands)) !== -1 && myCommands.splice(idx, 1);

--- a/elFinder.NetCore/Connector.cs
+++ b/elFinder.NetCore/Connector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -27,6 +28,22 @@ namespace elFinder.NetCore
         }
 
         public async Task<IActionResult> ProcessAsync(HttpRequest request)
+        {
+            try
+            {
+                return await ProcessCoreAsync(request);
+            }
+            catch (FileNotFoundException)
+            {
+                return Error.FileNotFound();
+            }
+            catch (DirectoryNotFoundException)
+            {
+                return Error.FolderNotFound();
+            }
+        }
+
+        protected async Task<IActionResult> ProcessCoreAsync(HttpRequest request)
         {
             var parameters = request.Query.Any()
                 ? request.Query.ToDictionary(k => k.Key, v => v.Value)

--- a/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
+++ b/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
@@ -149,7 +149,7 @@ namespace elFinder.NetCore.Drivers.FileSystem
 
                         if (!foundNewName)
                         {
-                            return Error.NewNameSelectionException($"{parentPath}{Path.DirectorySeparatorChar}{name} copy");
+                            return Error.NewNameSelectionException($"{name} copy");
                         }
                     }
 
@@ -183,7 +183,7 @@ namespace elFinder.NetCore.Drivers.FileSystem
 
                         if (!foundNewName)
                         {
-                            return Error.NewNameSelectionException($"{parentPath}{Path.DirectorySeparatorChar}{name} copy{ext}");
+                            return Error.NewNameSelectionException($"{name} copy{ext}");
                         }
                     }
                     response.Added.Add(await BaseModel.CreateAsync(new FileSystemFile(newName), path.RootVolume));

--- a/elFinder.NetCore/Helpers/Error.cs
+++ b/elFinder.NetCore/Helpers/Error.cs
@@ -31,7 +31,20 @@ namespace elFinder.NetCore.Helpers
 
         public static JsonResult NewNameSelectionException(string name)
         {
-            return new JsonResult(new { error = $"Unable to create new file with name {name}" });
+            return new JsonResult(new
+            {
+                error = new[] { "errNewNameSelection", name }
+            });
+        }
+
+        public static JsonResult FolderNotFound()
+        {
+            return FormatSimpleError("errFolderNotFound");
+        }
+
+        public static JsonResult FileNotFound()
+        {
+            return FormatSimpleError("errFileNotFound");
         }
 
         private static JsonResult FormatSimpleError(string message)


### PR DESCRIPTION
- Sometimes, in multiuser scenario, file/folder may be moved, deleted, renamed by another user before a request. Currently, a 500 response is returned.