### PR TITLE
Migration from System.Drawing.Common to SixLabors.ImageSharp

### DIFF
--- a/elFinder.NetCore/Drawing/IPictureEditor.cs
+++ b/elFinder.NetCore/Drawing/IPictureEditor.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+﻿using SixLabors.ImageSharp;
 using System.IO;
 
 namespace elFinder.NetCore.Drawing

--- a/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
+++ b/elFinder.NetCore/Drivers/FileSystem/FileSystemDriver.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net.Mime;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using elFinder.NetCore.Drawing;
 using elFinder.NetCore.Exceptions;
 using elFinder.NetCore.Extensions;
 using elFinder.NetCore.Helpers;
@@ -115,7 +114,9 @@ namespace elFinder.NetCore.Drivers.FileSystem
         public async Task<JsonResult> DimAsync(FullPath path)
         {
             using var stream = new FileStream(path.File.FullName, FileMode.Open);
-            var response = new DimResponseModel(path.RootVolume.PictureEditor.ImageSize(stream));
+            var size = path.RootVolume.PictureEditor.ImageSize(stream);
+            var sizeString = $"{size.Width} x {size.Height}";
+            var response = new DimResponseModel(sizeString);
             return await Json(response);
         }
 

--- a/elFinder.NetCore/elFinder.NetCore.csproj
+++ b/elFinder.NetCore/elFinder.NetCore.csproj
@@ -19,7 +19,7 @@
     <EmbeddedResource Include="MimeTypes.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="8.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
     <PackageReference Include="System.Text.Json" Version="8.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The decision to switch from System.Drawing.Common to SixLabors.ImageSharp was based on the first, on the latest versions, only supporting windows platform.
We plan on keeping our applications flexible that's why we decided to change library usage.
It's a personal preference. Feel free to discard this pull request if not interested.