### PR TITLE
Improve error handling and fix warnings

### DIFF
--- a/elFinder.NetCore.Web/Controllers/FileSystemController.cs
+++ b/elFinder.NetCore.Web/Controllers/FileSystemController.cs
@@ -20,6 +20,7 @@ namespace elFinder.NetCore.Web.Controllers
             }
             catch (Exception ex)
             {
+                //TODO: would be good to Sanitize Exception Message at least in production, can leak server file paths
                 return Json(new { error = "Unable to process your request: " + ex.Message });
             }
         }
@@ -27,8 +28,16 @@ namespace elFinder.NetCore.Web.Controllers
         [Route("thumb/{hash}")]
         public async Task<IActionResult> Thumbs(string hash)
         {
-            var connector = GetConnector();
-            return await connector.GetThumbnailAsync(HttpContext.Request, HttpContext.Response, hash);
+            try
+            {
+                var connector = GetConnector();
+                return await connector.GetThumbnailAsync(HttpContext.Request, HttpContext.Response, hash);
+            }
+            catch (Exception ex)
+            {
+                //TODO: would be good to Sanitize Exception Message at least in production, can leak server file paths
+                return Json(new { error = "Unable to process your request: " + ex.Message });
+            }
         }
 
         private Connector GetConnector()

--- a/elFinder.NetCore/Connector.cs
+++ b/elFinder.NetCore/Connector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using elFinder.NetCore.Drawing;
 using elFinder.NetCore.Drivers;
@@ -170,8 +171,9 @@ namespace elFinder.NetCore
 
                         if (encoding == "scheme")
                         {
-                            using var client = new WebClient();
-                            var data = await client.DownloadDataTaskAsync(new Uri(content));
+                            //TODO: It's worth noting that for optimal performance and resource management, HttpClient should not be instantiated for each request in a real-world application. Instead, it's typically best to create a single or few long-lived HttpClient instances and reuse them for all HTTP calls. This can be achieved through dependency injection or a static/singleton instance, depending on your application's architecture.
+                            using var client = new HttpClient();
+                            var data = await client.GetByteArrayAsync(new Uri(content));
                             return await driver.PutAsync(path, data);
                         }
                         else

--- a/elFinder.NetCore/Exceptions/FileTypeNotAllowedException.cs
+++ b/elFinder.NetCore/Exceptions/FileTypeNotAllowedException.cs
@@ -18,10 +18,5 @@ namespace elFinder.NetCore.Exceptions
             : base(message, innerException)
         {
         }
-
-        protected FileTypeNotAllowedException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
     }
 }

--- a/elFinder.NetCore/Exceptions/InvalidPathException.cs
+++ b/elFinder.NetCore/Exceptions/InvalidPathException.cs
@@ -18,10 +18,5 @@ namespace elFinder.NetCore.Exceptions
             : base(message, innerException)
         {
         }
-
-        protected InvalidPathException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-        }
     }
 }


### PR DESCRIPTION
Improve error handling return using json;
Fix rebuild warning messages: warning SYSLIB0051, warning SYSLIB0014. 
Use HttpClient instead of WebClient (obsolete).